### PR TITLE
fixed posixpath error when running anything from manage.py

### DIFF
--- a/musicbox/musicbox/settings.py
+++ b/musicbox/musicbox/settings.py
@@ -79,7 +79,7 @@ WSGI_APPLICATION = 'musicbox.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'NAME': str(BASE_DIR / 'db.sqlite3'),
     }
 }
 


### PR DESCRIPTION
just changed one line that gets rid of an error while debugging a population script... 'NAME' needs to be a string